### PR TITLE
複数新規著者登録機能の追加・安定化

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -42,14 +42,14 @@ class BooksController < ApplicationController
   end
 
   def author_assignment_params
-    params.require(:book).permit(:new_author_name, author_ids: [])
+    params.require(:book).permit(:new_author_names, author_ids: [], new_author_names: [])
   end
 
   def save_book(render_action, success_message)
     @book.assign_attributes(book_params)
-    @book.assign_authors_by_ids_and_name(
+    @book.assign_authors_by_ids_and_names(
       author_assignment_params[:author_ids],
-      author_assignment_params[:new_author_name]
+      author_assignment_params[:new_author_names]
     )
 
     if @book.save

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,5 +1,4 @@
 <h1>本を編集</h1>
-
 <%= form_with model: @book do |form| %>
   <% if @book.errors.any? %>
     <div id="error_explanation">
@@ -11,27 +10,22 @@
       </ul>
     </div>
   <% end %>
-
   <div class="field">
     <%= form.label :title %>
     <%= form.text_field :title %>
   </div>
-
   <div class="field">
     <%= form.label :isbn %>
     <%= form.text_field :isbn %>
   </div>
-
   <div class="field">
     <%= form.label :published_year %>
     <%= form.number_field :published_year %>
   </div>
-
   <div class="field">
     <%= form.label :publisher %>
     <%= form.text_field :publisher %>
   </div>
-
   <div class="field">
     <%= form.label :author_ids, "著者を選択" %>
     <%= form.collection_check_boxes :author_ids, Author.all, :id, :name do |b| %>
@@ -41,16 +35,13 @@
       </div>
     <% end %>
   </div>
-
   <div class="field">
-    <%= form.label :new_author_name, "または新しい著者名を入力" %>
-    <%= form.text_field :new_author_name %>
+    <%= form.label :new_author_names, "新しい著者名を入力（カンマ区切りで複数可）" %>
+    <%= form.text_area :new_author_names, placeholder: "新しい著者名を入力" %>
   </div>
-
   <div class="actions">
     <%= form.submit %>
   </div>
 <% end %>
-
 <%= link_to '詳細', @book %> |
 <%= link_to '戻る', books_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,5 +1,4 @@
 <h1>新しい本を登録</h1>
-
 <%= form_with model: @book do |form| %>
   <% if @book.errors.any? %>
     <div id="error_explanation">
@@ -11,27 +10,22 @@
       </ul>
     </div>
   <% end %>
-
   <div class="field">
     <%= form.label :title %>
     <%= form.text_field :title %>
   </div>
-
   <div class="field">
     <%= form.label :isbn %>
     <%= form.text_field :isbn %>
   </div>
-
   <div class="field">
     <%= form.label :published_year %>
     <%= form.number_field :published_year %>
   </div>
-
   <div class="field">
     <%= form.label :publisher %>
     <%= form.text_field :publisher %>
   </div>
-
   <div class="field">
     <%= form.label :author_ids, "著者を選択" %>
     <%= form.collection_check_boxes :author_ids, Author.all, :id, :name do |b| %>
@@ -41,15 +35,12 @@
       </div>
     <% end %>
   </div>
-
   <div class="field">
-    <%= form.label :new_author_name, "または新しい著者名を入力" %>
-    <%= form.text_field :new_author_name %>
+    <%= form.label :new_author_names, "新しい著者名を入力（カンマ区切りで複数可）" %>
+    <%= form.text_area :new_author_names, placeholder: "新しい著者名を入力" %>
   </div>
-
   <div class="actions">
     <%= form.submit %>
   </div>
 <% end %>
-
 <%= link_to '戻る', books_path %>

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -82,7 +82,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
           isbn: '9876543210',
           published_year: 2023,
           publisher: '新出版社',
-          new_author_name: '新著者'
+          new_author_names: ['新著者']
         }
       }
     end
@@ -105,6 +105,27 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
       }
     end
     assert_equal 2, Book.last.authors.count
+  end
+
+  # 複数の新しい著者を登録するテスト
+  test 'should create book with multiple new authors' do
+    sign_in @user
+    assert_difference('Book.count', 1) do
+      assert_difference('Author.count', 2) do
+        post books_url, params: {
+          book: {
+            title: '新しい本',
+            isbn: '9876543210',
+            published_year: 2023,
+            publisher: '新出版社',
+            new_author_names: %w[新著者A 新著者B]
+          }
+        }
+      end
+    end
+    assert_redirected_to book_url(Book.last)
+    assert_includes Book.last.authors.map(&:name), '新著者A'
+    assert_includes Book.last.authors.map(&:name), '新著者B'
   end
 
   # Edit アクションのテスト
@@ -142,7 +163,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
           published_year: @book.published_year,
           publisher: @book.publisher,
           author_ids: [@author.id],
-          new_author_name: '追加著者'
+          new_author_names: ['追加著者']
         }
       }
     end

--- a/test/integration/books_management_test.rb
+++ b/test/integration/books_management_test.rb
@@ -45,7 +45,7 @@ class BooksManagementTest < ActionDispatch::IntegrationTest
           published_year: book.published_year,
           publisher: book.publisher,
           author_ids: [@author.id],
-          new_author_name: '新しい著者'
+          new_author_names: ['新しい著者']
         }
       }
     end


### PR DESCRIPTION
このPRは、1回の操作で複数の新規著者をBookに割り当てられるようにします。複数著者の受け入れが増えているカタログ登録フローに合わせた改善です。

# 変更点
- コントローラー: strong parametersをauthor_idsとnew_author_namesに対応（文字列/配列の両対応）させ、モデルのassign_authors_by_ids_and_namesに一本化。従来の単一new_author_name経路を廃止。
- モデル(Book): assign_authors_by_ids_and_namesを追加し、入力（文字列/配列、カンマ/改行区切り）を正規化、トリム、重複排除してauthor_idsにマージ。AuthorCreationErrorを定義し、RecordNotUnique発生時の再取得で並行作成にも耐性を付与。デバッグログを追加。
- ビュー（new/edit）: 単一のnew_author_nameフィールドを廃止し、複数入力可能なnew_author_namesのtextareaに置き換え（カンマ/改行で区切り）。既存著者のチェックボックス選択は維持。
- テスト: 既存のnew_author_name入力をnew_author_namesに移行しつつ、既存著者選択＋新規著者複数作成のケースを追加。